### PR TITLE
Enable using built-in libexpat on Linux

### DIFF
--- a/expat/lib/macconfig.h
+++ b/expat/lib/macconfig.h
@@ -34,7 +34,11 @@
 #define STDC_HEADERS 1
 #define HAVE_MEMMOVE 1
 #define HAVE_BCOPY 1
+#if defined( __APPLE__ )
 #define HAVE_ARC4RANDOM_BUF 1
+#else
+#define HAVE_GETRANDOM 1
+#endif
 #define HAVE_FCNTL_H 1
 #define HAVE_UNISTD_H 1
 #define HAVE_STDLIB_H 1

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -62,10 +62,10 @@
 
 #ifdef _WIN32
 #  include "winconfig.h"
-#elif defined( __APPLE__ ) && !defined(HAVE_EXPAT_CONFIG_H)
-#  include "macconfig.h"
 #elif defined(HAVE_EXPAT_CONFIG_H)
 #  include <expat_config.h>
+#else
+#  include "macconfig.h"
 #endif /* ndef _WIN32 */
 
 #include "ascii.h"

--- a/expat/lib/xmlrole.c
+++ b/expat/lib/xmlrole.c
@@ -37,7 +37,7 @@
 #else
 #  ifdef HAVE_EXPAT_CONFIG_H
 #    include <expat_config.h>
-#  elif defined( __APPLE__ )
+#  else
 #    include "macconfig.h"
 #  endif
 #endif /* ndef _WIN32 */

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -47,7 +47,7 @@
 #else
 #  ifdef HAVE_EXPAT_CONFIG_H
 #    include <expat_config.h>
-#  elif defined( __APPLE__ )
+#  else
 #    include "macconfig.h"
 #  endif
 #endif /* ndef _WIN32 */


### PR DESCRIPTION
Required to make https://github.com/wxWidgets/wxWidgets/commit/f25a88a13dc51d9d857e10b4b264c0e817bb7a0f actually work